### PR TITLE
npm config tmp should have precedence over /tmp

### DIFF
--- a/install.js
+++ b/install.js
@@ -142,8 +142,8 @@ function exit(code) {
 function findSuitableTempDirectory(npmConf) {
   var now = Date.now()
   var candidateTmpDirs = [
-    process.env.TMPDIR || process.env.TEMP || '/tmp',
-    npmConf.get('tmp'),
+    process.env.TMPDIR || process.env.TEMP || npmConf.get('tmp'),
+    '/tmp',
     path.join(process.cwd(), 'tmp')
   ]
 


### PR DESCRIPTION
Previously /tmp would always be tried before `npmConf.get('tmp')`
